### PR TITLE
JENKINS-37136 Make compatible with Jenkins pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.1</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.568</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>1.4.0</version>
+      <version>2.3</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/git/chooser/alternative/AlternativeBuildChooser.java
+++ b/src/main/java/org/jenkinsci/plugins/git/chooser/alternative/AlternativeBuildChooser.java
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.git.chooser.alternative;
 
 import hudson.Extension;
 import hudson.EnvVars;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -37,13 +37,13 @@ public class AlternativeBuildChooser extends BuildChooser {
 	                                                  TaskListener listener,
 	                                                  BuildData data,
 	                                                  BuildChooserContext context)
-	                            throws GitException, IOException {
+	                            throws GitException, IOException, InterruptedException {
 		verbose(listener, "AlternativeBuildChooser.getCandidateRevisions()");
 		EnvVars env = null;
 		if (!isPollCall) try {
-			env = context.actOnBuild(new BuildChooserContext.ContextCallable<AbstractBuild<?,?>, EnvVars>() {
-				public EnvVars invoke(AbstractBuild<?,?> build, hudson.remoting.VirtualChannel channel) throws IOException, InterruptedException {
-					return build.getEnvironment();
+			env = context.actOnBuild(new BuildChooserContext.ContextCallable<Run<?,?>, EnvVars>() {
+				public EnvVars invoke(Run<?,?> run, hudson.remoting.VirtualChannel channel) throws IOException, InterruptedException {
+					return run.getEnvironment();
 				}
 			});
 		} catch (InterruptedException x) {
@@ -64,7 +64,7 @@ public class AlternativeBuildChooser extends BuildChooser {
 	                              Collection<Branch> remoteBranches,
 	                              TaskListener listener,
 	                              BuildData data, BuildChooserContext context)
-	                 throws GitException, IOException {
+	                 throws GitException, IOException, InterruptedException {
 		Revision r = null;
 		ObjectId sha1;
 		if (spec.getName().matches("[0-9a-f]{6,40}")) {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
+++ b/src/test/java/hudson/plugins/git/AbstractGitTestCase.java
@@ -1,11 +1,32 @@
 package hudson.plugins.git;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
 import hudson.EnvVars;
 import hudson.FilePath;
-import hudson.model.*;
-import hudson.plugins.git.util.DefaultBuildChooser;
+import hudson.Functions;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixProject;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Hudson;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.FreeStyleProject;
+import hudson.model.Node;
+import hudson.plugins.git.extensions.GitClientType;
+import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.impl.EnforceGitClient;
+import hudson.plugins.git.extensions.impl.DisableRemotePoll;
+import hudson.plugins.git.extensions.impl.PathRestriction;
+import hudson.plugins.git.extensions.impl.RelativeTargetDirectory;
+import hudson.plugins.git.extensions.impl.SparseCheckoutPath;
+import hudson.plugins.git.extensions.impl.SparseCheckoutPaths;
+import hudson.plugins.git.extensions.impl.UserExclusion;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.triggers.SCMTrigger;
+import hudson.triggers.SCMTrigger.SCMTriggerCause;
 import hudson.util.StreamTaskListener;
 
 import java.io.File;
@@ -13,11 +34,13 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
-import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jenkinsci.plugins.gitclient.JGitTool;
 import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 
 
 /**
@@ -52,23 +75,37 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
         git = testRepo.git;
     }
 
-    protected void commit(final String fileName, final PersonIdent committer, final String message) throws GitException {
+    @Override
+    protected void tearDown() throws Exception {
+        try { //Avoid test failures due to failed cleanup tasks
+            super.tearDown();
+        } catch (Exception e) {
+            if (e instanceof IOException && Functions.isWindows()) {
+                return;
+            }
+            e.printStackTrace();
+        }
+    }
+
+    protected void commit(final String fileName, final PersonIdent committer, final String message)
+            throws GitException, InterruptedException {
     	testRepo.commit(fileName, committer, message);
     }
 
-    protected void commit(final String fileName, final String fileContent, final PersonIdent committer, final String message) throws GitException {
+    protected void commit(final String fileName, final String fileContent, final PersonIdent committer, final String message)
+
+            throws GitException, InterruptedException {
     	testRepo.commit(fileName, fileContent, committer, message);
     }
 
     protected void commit(final String fileName, final PersonIdent author, final PersonIdent committer,
-                        final String message) throws GitException {
+                        final String message) throws GitException, InterruptedException {
     	testRepo.commit(fileName, author, committer, message);
     }
 
     protected List<UserRemoteConfig> createRemoteRepositories() throws IOException {
         return testRepo.remoteConfigs();
     }
-
 
     protected FreeStyleProject setupProject(String branchString, boolean authorOrCommitter) throws Exception {
         return setupProject(branchString, authorOrCommitter, null);
@@ -107,23 +144,79 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
     }
 
     protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter,
-                                          String relativeTargetDir, String excludedRegions,
-                                          String excludedUsers, String localBranch, boolean fastRemotePoll,
-                                          String includedRegions) throws Exception {
+                                            String relativeTargetDir, String excludedRegions,
+                                            String excludedUsers, String localBranch, boolean fastRemotePoll,
+                                            String includedRegions) throws Exception {
+        return setupProject(branches,
+                authorOrCommitter, relativeTargetDir, excludedRegions,
+                excludedUsers, localBranch, fastRemotePoll,
+                includedRegions, null);
+    }
+
+    protected FreeStyleProject setupProject(String branchString, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
+        return setupProject(Collections.singletonList(new BranchSpec(branchString)),
+                false, null, null,
+                null, null, false,
+                null, sparseCheckoutPaths);
+    }
+
+    protected FreeStyleProject setupProject(List<BranchSpec> branches, boolean authorOrCommitter,
+                String relativeTargetDir, String excludedRegions,
+                String excludedUsers, String localBranch, boolean fastRemotePoll,
+                String includedRegions, List<SparseCheckoutPath> sparseCheckoutPaths) throws Exception {
         FreeStyleProject project = createFreeStyleProject();
-        project.setScm(new GitSCM(
-                null,
+        GitSCM scm = new GitSCM(
                 createRemoteRepositories(),
                 branches,
-                null,
-                false, Collections.<SubmoduleConfig>emptyList(), false,
-                false, new DefaultBuildChooser(), null, null, authorOrCommitter, relativeTargetDir, null,
-                excludedRegions, excludedUsers, localBranch, false, false, false, fastRemotePoll, null, null, false,
-                includedRegions, false, false));
+                false, Collections.<SubmoduleConfig>emptyList(),
+                null, null,
+                Collections.<GitSCMExtension>emptyList());
+        scm.getExtensions().add(new DisableRemotePoll()); // don't work on a file:// repository
+        if (relativeTargetDir!=null)
+            scm.getExtensions().add(new RelativeTargetDirectory(relativeTargetDir));
+        if (excludedUsers!=null)
+            scm.getExtensions().add(new UserExclusion(excludedUsers));
+        if (excludedRegions!=null || includedRegions!=null)
+            scm.getExtensions().add(new PathRestriction(includedRegions,excludedRegions));
+
+        scm.getExtensions().add(new SparseCheckoutPaths(sparseCheckoutPaths));
+
+        project.setScm(scm);
         project.getBuildersList().add(new CaptureEnvironmentBuilder());
         return project;
     }
 
+    /**
+     * Creates a new project and configures the GitSCM according the parameters.
+     * @param repos
+     * @param branchSpecs
+     * @param scmTriggerSpec
+     * @param disableRemotePoll Disable Workspace-less polling via "git ls-remote"
+     * @return
+     * @throws Exception
+     */
+    protected FreeStyleProject setupProject(List<UserRemoteConfig> repos, List<BranchSpec> branchSpecs,
+                String scmTriggerSpec, boolean disableRemotePoll, EnforceGitClient enforceGitClient) throws Exception {
+        FreeStyleProject project = createFreeStyleProject();
+        GitSCM scm = new GitSCM(
+                    repos,
+                    branchSpecs,
+                    false, Collections.<SubmoduleConfig>emptyList(),
+                    null, JGitTool.MAGIC_EXENAME,
+                    Collections.<GitSCMExtension>emptyList());
+        if(disableRemotePoll) scm.getExtensions().add(new DisableRemotePoll());
+        if(enforceGitClient != null) scm.getExtensions().add(enforceGitClient);
+        project.setScm(scm);
+        if(scmTriggerSpec != null) {
+            SCMTrigger trigger = new SCMTrigger(scmTriggerSpec);
+            project.addTrigger(trigger);
+            trigger.start(project, true);
+        }
+        //project.getBuildersList().add(new CaptureEnvironmentBuilder());
+        project.save();
+        return project;
+    }
+    
     protected FreeStyleProject setupSimpleProject(String branchString) throws Exception {
         return setupProject(branchString,false);
     }
@@ -151,6 +244,19 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
         }
         return build;
     }
+    
+    protected MatrixBuild build(final MatrixProject project, final Result expectedResult, final String...expectedNewlyCommittedFiles) throws Exception {
+        final MatrixBuild build = project.scheduleBuild2(0, new Cause.UserCause()).get();
+        System.out.println(build.getLog());
+        for(final String expectedNewlyCommittedFile : expectedNewlyCommittedFiles) {
+            assertTrue(expectedNewlyCommittedFile + " file not found in workspace", build.getWorkspace().child(expectedNewlyCommittedFile).exists());
+        }
+        if(expectedResult != null) {
+            assertBuildStatus(expectedResult, build);
+        }
+        return build;
+    }
+    
 
     protected EnvVars getEnvVars(FreeStyleProject project) {
         for (hudson.tasks.Builder b : project.getBuilders()) {
@@ -172,7 +278,8 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
         return build.getWorkspace().act(new FilePath.FileCallable<String>() {
                 public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
                     try {
-                        return Git.with(null, null).in(f).getClient().getRepository().resolve("refs/heads/"+ branch).name();
+                        ObjectId oid = Git.with(null, null).in(f).getClient().getRepository().resolve("refs/heads/" + branch);
+                        return oid.name();
                     } catch (GitException e) {
                         throw new RuntimeException(e);
                     }
@@ -180,4 +287,3 @@ public abstract class AbstractGitTestCase extends HudsonTestCase {
             });
     }
 }
-

--- a/src/test/java/hudson/plugins/git/README
+++ b/src/test/java/hudson/plugins/git/README
@@ -1,5 +1,5 @@
 
 Since test classes apparently aren't included in maven dependency
 resolution, these test classes are copied from
-https://github.com/jenkinsci/git-plugin/blob/git-1.4.0/src/test/java/hudson/plugins/git/
+https://github.com/jenkinsci/git-plugin/blob/git-2.3/src/test/java/hudson/plugins/git/
 

--- a/src/test/java/hudson/plugins/git/TestGitRepo.java
+++ b/src/test/java/hudson/plugins/git/TestGitRepo.java
@@ -34,13 +34,18 @@ public class TestGitRepo {
 	public final PersonIdent johnDoe = new PersonIdent("John Doe", "john@doe.com");
 	public final PersonIdent janeDoe = new PersonIdent("Jane Doe", "jane@doe.com");
     
-	public TestGitRepo(String name, HudsonTestCase forTest, TaskListener listener) throws IOException {
+	public TestGitRepo(String name, HudsonTestCase forTest, TaskListener listener)
+            throws IOException, InterruptedException {
+        this(name, forTest.createTmpDir(), listener);
+    }
+
+    public TestGitRepo(String name, File tmpDir, TaskListener listener) throws IOException, InterruptedException {
 		this.name = name;
 		this.listener = listener;
 		
 		envVars = new EnvVars();
 		
-		gitDir = forTest.createTmpDir();
+		gitDir = tmpDir;
 		User john = User.get(johnDoe.getName(), true);
 		UserProperty johnsMailerProperty = new Mailer.UserProperty(johnDoe.getEmailAddress());
 		john.addProperty(johnsMailerProperty);
@@ -57,20 +62,25 @@ public class TestGitRepo {
 		git.init();
 	}
 	
-    public void commit(final String fileName, final PersonIdent committer, final String message) throws GitException {
+    public void commit(final String fileName, final PersonIdent committer, final String message)
+            throws GitException, InterruptedException {
         commit(fileName, fileName, committer, committer, message);
     }
 
-    public void commit(final String fileName, final PersonIdent author, final PersonIdent committer, final String message) throws GitException {
+    public void commit(final String fileName, final PersonIdent author, final PersonIdent committer, final String message)
+
+            throws GitException, InterruptedException {
         commit(fileName, fileName, author, committer, message);
     }
 
-    public void commit(final String fileName, final String fileContent, final PersonIdent committer, final String message) throws GitException {
+    public void commit(final String fileName, final String fileContent, final PersonIdent committer, final String message)
+
+            throws GitException, InterruptedException {
         commit(fileName, fileContent, committer, committer, message);
     }
 
     public void commit(final String fileName, final String fileContent, final PersonIdent author, final PersonIdent committer,
-                        final String message) throws GitException {
+                        final String message) throws GitException, InterruptedException {
         FilePath file = gitDirPath.child(fileName);
         try {
             file.write(fileContent, null);
@@ -83,8 +93,7 @@ public class TestGitRepo {
 
     public List<UserRemoteConfig> remoteConfigs() throws IOException {
         List<UserRemoteConfig> list = new ArrayList<UserRemoteConfig>();
-        list.add(new UserRemoteConfig(gitDir.getAbsolutePath(), "origin", ""));
+        list.add(new UserRemoteConfig(gitDir.getAbsolutePath(), "origin", "", null));
         return list;
     }
 }
-

--- a/src/test/java/hudson/plugins/git/extensions/impl/EnforceGitClient.java
+++ b/src/test/java/hudson/plugins/git/extensions/impl/EnforceGitClient.java
@@ -1,0 +1,39 @@
+package hudson.plugins.git.extensions.impl;
+
+import hudson.Extension;
+import hudson.plugins.git.extensions.FakeGitSCMExtension;
+import hudson.plugins.git.extensions.GitClientType;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Enforce JGit Client
+ */
+public class EnforceGitClient extends FakeGitSCMExtension {
+
+    GitClientType clientType = GitClientType.ANY;
+    
+    public EnforceGitClient set(GitClientType type) {
+        this.clientType = type;
+        return this;
+    }
+    
+    @Override
+    public GitClientType getRequiredClient()
+    {
+        return clientType;
+    }
+
+    @DataBoundConstructor
+    public EnforceGitClient() {
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Enforce JGit Client";
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the git-chooser-alternative-plugin compatible with Jenkins pipeline. The big change is to move to using hudson.model.Run instead of hudson.model.AbstractBuild. To do this, this required upgrading the Jenkins Git plugin dependency to a version that supports Jenkins pipeline, of which the earliest is the 2.3 series.

I made the jenkins plugin API match the 1.568 version that is used in that Git plugin, and copied over the corresponding test APIs from the newer version of the Jenkins Git plugin. The new version of the plugin also exposed InterruptedException more explicitly, so those had to bubble up into the signatures inside AlternativeBuildChooser. The newer version of the Git plugin also required the new escape-by-default header on the index.jelly file.

This is tested to work in pipeline jobs in Jenkins 2.60.1; no attempt to explicitly test the backwards compatibility with the FreeStyle jobs GUI, but the existing unit tests seem to cover those.